### PR TITLE
TOP SELLERS FIX#1

### DIFF
--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -21,7 +21,7 @@ const TopSellers = () => {
   function renderTopSellers() {
     return loading
       ? new Array(12).fill(0).map((_, index) => (
-          <li>
+          <li key={index}>
             <div className="author_list_pp">
               <a href="/">
                 <div


### PR DESCRIPTION
added key={index} to renderTopSellers() because it was causing a console error.